### PR TITLE
add selector option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
-test/fixtures/*/build
+test/fixtures/**/build
+
+.idea/

--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,30 @@ var excerpts = require('metalsmith-excerpts');
 metalsmith.use(excerpts());
 ```
 
+## Consuming Excerpts From Metadata
+
+  The excerpt HTML will be added to an `excerpt` property on the metadata. Here's sample usage in Jade:
+  
+```jade
+each post in collections.posts
+  div!= post.excerpt
+```
+
+## Options
+
+### selector
+
+  Passing a `selector` to excerpts will cause it to extract the first element matching that selector
+  pattern, instead of the default 'p' selector.
+  
+```js
+var excerpts = require('metalsmith-excerpts');
+
+metalsmith.use(excerpts({
+  selector: 'code'
+}));
+```  
+
 ## License
 
   MIT

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,15 @@ function plugin(options){
 
       debug('storing excerpt: %s', file);
       var $ = cheerio.load(data.contents.toString());
-      var p = $('p').first();
-      data.excerpt = $.html(p).trim();
+
+      var selector = 'p';
+
+      if (options && options.selector){
+        selector = options.selector;
+      }
+
+      var element = $(selector).first();
+      data.excerpt = $.html(element).trim();
     });
   };
 }

--- a/test/fixtures/options/selector-class/src/index.md
+++ b/test/fixtures/options/selector-class/src/index.md
@@ -1,0 +1,8 @@
+---
+title: Testing selector option on class
+---
+
+This is first paragraph.
+
+<p class="spotlight">This is the second paragraph.</p>
+

--- a/test/fixtures/options/selector-code/src/index.md
+++ b/test/fixtures/options/selector-code/src/index.md
@@ -1,0 +1,10 @@
+---
+title: Testing selector option on code block
+---
+
+```
+This is code.
+```
+
+This is not code.
+

--- a/test/index.js
+++ b/test/index.js
@@ -59,4 +59,32 @@ describe('metalsmith-excerpts', function(){
         done();
       });
   });
+
+  describe('options', function() {
+    it('should use the given tag selector when provided', function(done) {
+      Metalsmith('test/fixtures/options/selector-code')
+        .use(markdown())
+        .use(excerpt({
+          selector: 'code'
+        }))
+        .build(function(err, files) {
+          if (err) return done(err);
+          assert.equal('<code>This is code.\n</code>', files['index.html'].excerpt);
+          done();
+        });
+    });
+
+    it('should use the given class selector when provided', function(done) {
+      Metalsmith('test/fixtures/options/selector-class')
+        .use(markdown())
+        .use(excerpt({
+          selector: '.spotlight'
+        }))
+        .build(function(err, files) {
+          if (err) return done(err);
+          assert.equal('<p class="spotlight">This is the second paragraph.</p>', files['index.html'].excerpt);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
I added an option to supply a selector to the plugin to determine what to extract into the `excerpt` metadata property. Also, documentation on existence/usage of `excerpt` has been added to the README.
