### PR TITLE
excerpt can be now returned without surround <p>

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = plugin;
  */
 
 function plugin(options){
+
   return function(files, metalsmith, done){
     setImmediate(done);
     Object.keys(files).forEach(function(file){
@@ -27,11 +28,13 @@ function plugin(options){
       if (typeof data.excerpt === 'string' && data.excerpt.length) {
         return; // don't mutate data
       }
-
-      debug('storing excerpt: %s', file);
       var $ = cheerio.load(data.contents.toString());
       var p = $('p').first();
-      data.excerpt = $.html(p).trim();
+      
+      data.excerpt = options && options.selector==='innerHTML'? $(p).html():$.html(p) 
+      data.excerpt && data.excerpt.trim();
+
+      debug('storing excerpt: %s, %s', file, data.excerpt);
     });
   };
 }


### PR DESCRIPTION
please consider this as an enhancement, sometimes we need the excerpt as text (or inner HTML without the surrouding <p>", I have added optional option.selector, which can have now only one value
innerHTML, if specified, it does return innerHTML, if not it returns the same as before.

Thanx
